### PR TITLE
Adding Laravel 5.6 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 5.0.0 (released 2018-02-02)
+
+- Added laravel 5.6 support
+- Dropped php 7.0 support
+
 ## 4.0.0 (released 2017-10-23)
 
 - Update namespace to Pusher

--- a/composer.json
+++ b/composer.json
@@ -11,18 +11,18 @@
         }
     ],
     "require": {
-        "php": "^7.0",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*",
-        "graham-campbell/manager": "^3.0",
+        "php": "^7.1.3",
+        "illuminate/contracts": "5.6.*",
+        "illuminate/support": "5.6.*",
+        "graham-campbell/manager": "^4.0",
         "pusher/pusher-php-server": "^3.0"
     },
     "require-dev": {
         "graham-campbell/analyzer": "^1.1",
-        "graham-campbell/testbench": "^4.0",
+        "graham-campbell/testbench": "^5.0",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^3.5",
-        "phpunit/phpunit": "^6.3"
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -39,7 +39,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.0-dev"
+            "dev-master": "5.0-dev"
         },
         "laravel": {
             "providers": [


### PR DESCRIPTION
For fixing #31 this adds Laravel 5.6 support, therefore the minimum php version requirement is now  >= 7.1.3