### PR TITLE
Switch config file to use env variables by default

### DIFF
--- a/config/pusher.php
+++ b/config/pusher.php
@@ -43,7 +43,9 @@ return [
             'auth_key' => env('PUSHER_APP_KEY'),
             'secret' => env('PUSHER_APP_SECRET'),
             'app_id' => env('PUSHER_APP_ID'),
-            'options' => [],
+            'options' => [
+                'cluster' => env('PUSHER_APP_CLUSTER'),
+            ],
             'host' => null,
             'port' => null,
             'timeout' => null,

--- a/config/pusher.php
+++ b/config/pusher.php
@@ -40,9 +40,9 @@ return [
     'connections' => [
 
         'main' => [
-            'auth_key' => 'your-auth-key',
-            'secret' => 'your-secret',
-            'app_id' => 'your-app-id',
+            'auth_key' => env('PUSHER_APP_KEY'),
+            'secret' => env('PUSHER_APP_SECRET'),
+            'app_id' => env('PUSHER_APP_ID'),
             'options' => [],
             'host' => null,
             'port' => null,

--- a/src/PusherFactory.php
+++ b/src/PusherFactory.php
@@ -64,7 +64,7 @@ class PusherFactory
             }
         }
         
-        foreach($config['options'] as $option => $value) {
+        foreach ($config['options'] as $option => $value) {
             if (is_null($value)) {
                 unset($config['options'][$option]);
             }

--- a/src/PusherFactory.php
+++ b/src/PusherFactory.php
@@ -63,6 +63,12 @@ class PusherFactory
                 throw new InvalidArgumentException("Missing configuration key [$key].");
             }
         }
+        
+        foreach($config['options'] as $option => $value) {
+            if (is_null($value)) {
+                unset($config['options'][$option]);
+            }
+        }
 
         return array_only($config, $keys);
     }


### PR DESCRIPTION
This will:
- reduce the number of steps involved in setting up
- prevent unsuspecting newbies from entering their credentials directly into the config file (and possibly version control)