### PR TITLE
Fix composer.json to use up to date pusher-http-php dep

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/contracts": "5.5.*|5.6.*|5.7.*",
         "illuminate/support": "5.5.*|5.6.*|5.7.*",
         "graham-campbell/manager": "^3.0|^4.0",
-        "pusher/pusher-php-server": "^3.0"
+        "pusher/pusher-php-server": "^3.3"
     },
     "require-dev": {
         "graham-campbell/analyzer": "^1.1",


### PR DESCRIPTION
Currently, users who update the lib without updating its deps might find themselves in a position where e2e should work but can't.

This pins the Pusher-http-php dep to a version that supports e2e.