### PR TITLE
Require a version of pusher-php-server that supports E2E encryption

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/contracts": "5.5.*|5.6.*|5.7.*",
         "illuminate/support": "5.5.*|5.6.*|5.7.*",
         "graham-campbell/manager": "^3.0|^4.0",
-        "pusher/pusher-php-server": "^3.0"
+        "pusher/pusher-php-server": "^3.3"
     },
     "require-dev": {
         "graham-campbell/analyzer": "^1.1",


### PR DESCRIPTION
This was missing from PR #39.