### PR TITLE
Make it clear the library is deprecated in the package description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "pusher/pusher-http-laravel",
-    "description": "A Pusher bridge for Laravel",
+    "description": "[DEPRECATED] A Pusher bridge for Laravel",
     "license": "MIT",
     "keywords": ["laravel", "pusher", "http", "api", "php-pusher-server", "rest", "realtime", "trigger", "publish", "events"],
     "authors": [


### PR DESCRIPTION
The package description is displayed in a prominent location on https://packagist.org/packages/pusher/pusher-http-laravel, so I thought it would be good to label it as deprecated there too.